### PR TITLE
`DeepSparseModelForSequenceClassification` and `input_shapes`

### DIFF
--- a/optimum/deepsparse/__init__.py
+++ b/optimum/deepsparse/__init__.py
@@ -20,6 +20,7 @@ from transformers.utils import _LazyModule
 _import_structure = {
     "modeling": [
         "DeepSparseModel",
+        "DeepSparseModelForSequenceClassification",
         "DeepSparseModelForImageClassification",
     ],
 }
@@ -29,6 +30,7 @@ if TYPE_CHECKING:
     from .modeling import (
         DeepSparseModel,
         DeepSparseModelForImageClassification,
+        DeepSparseModelForSequenceClassification,
     )
 else:
     import sys

--- a/optimum/deepsparse/modeling.py
+++ b/optimum/deepsparse/modeling.py
@@ -157,10 +157,6 @@ class DeepSparseModelForImageClassification(DeepSparseModel):
     export_feature = "image-classification"
     auto_model_class = AutoModelForImageClassification
 
-    def __init__(self, model=None, config=None, **kwargs):
-        super().__init__(model, config, **kwargs)
-        self.input_names = ["pixel_values"]
-
     @add_start_docstrings_to_model_forward(
         IMAGE_INPUTS_DOCSTRING.format("batch_size, num_channels, height, width")
         + IMAGE_CLASSIFICATION_EXAMPLE.format(
@@ -252,7 +248,7 @@ class DeepSparseModelForSequenceClassification(DeepSparseModel):
         + SEQUENCE_CLASSIFICATION_EXAMPLE.format(
             processor_class=_TOKENIZER_FOR_DOC,
             model_class="DeepSparseModelForSequenceClassification",
-            checkpoint="optimum/distilbert-base-uncased-finetuned-sst-2-english",
+            checkpoint="distilbert-base-uncased-finetuned-sst-2-english",
         )
     )
     def forward(

--- a/optimum/deepsparse/modeling.py
+++ b/optimum/deepsparse/modeling.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Union
 
 import numpy as np
 import torch
@@ -10,11 +10,13 @@ from transformers import (
     AutoConfig,
     AutoModel,
     AutoModelForImageClassification,
+    AutoModelForSequenceClassification,
     EvalPrediction,
 )
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import (
     ImageClassifierOutput,
+    SequenceClassifierOutput,
 )
 
 from .modeling_base import DeepSparseBaseModel
@@ -23,7 +25,9 @@ from .modeling_base import DeepSparseBaseModel
 logger = logging.getLogger(__name__)
 
 
+_TOKENIZER_FOR_DOC = "AutoTokenizer"
 _FEATURE_EXTRACTOR_FOR_DOC = "AutoFeatureExtractor"
+_PROCESSOR_FOR_DOC = "AutoProcessor"
 
 MODEL_START_DOCSTRING = r"""
     This model inherits from [`optimum.deepsparse.DeepSparseBaseModel`]. Check the superclass documentation for the generic methods the
@@ -35,6 +39,26 @@ MODEL_START_DOCSTRING = r"""
             Initializing with a config file does not load the weights associated with the model, only the configuration.
         deepsparse_config (`Optional[Dict]`, defaults to `None`):
             The dictionnary containing the informations related to the model compilation.
+"""
+
+TEXT_INPUTS_DOCSTRING = r"""
+    Args:
+        input_ids (`Union[torch.Tensor, np.ndarray, None]` of shape `({0})`, defaults to `None`):
+            Indices of input sequence tokens in the vocabulary.
+            Indices can be obtained using [`AutoTokenizer`](https://huggingface.co/docs/transformers/autoclass_tutorial#autotokenizer).
+            See [`PreTrainedTokenizer.encode`](https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizerBase.encode) and
+            [`PreTrainedTokenizer.__call__`](https://huggingface.co/docs/transformers/main_classes/tokenizer#transformers.PreTrainedTokenizerBase.__call__) for details.
+            [What are input IDs?](https://huggingface.co/docs/transformers/glossary#input-ids)
+        attention_mask (`Union[torch.Tensor, np.ndarray, None]` of shape `({0})`, defaults to `None`):
+            Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **masked**.
+            [What are attention masks?](https://huggingface.co/docs/transformers/glossary#attention-mask)
+        token_type_ids (`Union[torch.Tensor, np.ndarray, None]` of shape `({0})`, defaults to `None`):
+            Segment token indices to indicate first and second portions of the inputs. Indices are selected in `[0, 1]`:
+            - 1 for tokens that are **sentence A**,
+            - 0 for tokens that are **sentence B**.
+            [What are token type IDs?](https://huggingface.co/docs/transformers/glossary#token-type-ids)
 """
 
 IMAGE_INPUTS_DOCSTRING = r"""
@@ -147,15 +171,112 @@ class DeepSparseModelForImageClassification(DeepSparseModel):
     )
     def forward(
         self,
-        pixel_values: None,
+        pixel_values: Union[torch.Tensor, np.ndarray],
         **kwargs,
     ):
         self.compile()
 
-        np_inputs = isinstance(pixel_values, np.ndarray)
-        if not np_inputs:
-            pixel_values = np.array(pixel_values)
+        use_torch = isinstance(pixel_values, torch.Tensor)
+        if use_torch:
+            pixel_values = pixel_values.cpu().detach().numpy()
 
         outputs = self.deepsparse_engine(list(np.expand_dims(pixel_values, axis=0)))
-        logits = torch.from_numpy(outputs[0]) if not np_inputs else outputs[0]
+        logits = torch.from_numpy(outputs[0]) if use_torch else outputs[0]
+
+        # converts output to namedtuple for pipelines post-processing
         return ImageClassifierOutput(logits=logits)
+
+
+SEQUENCE_CLASSIFICATION_EXAMPLE = r"""
+    Example of single-label classification:
+
+    ```python
+    >>> from transformers import {processor_class}
+    >>> from optimum.deepsparse import {model_class}
+    >>> import torch
+
+    >>> tokenizer = {processor_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}")
+
+    >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="np")
+
+    >>> outputs = model(**inputs)
+    >>> logits = outputs.logits
+    >>> list(logits.shape)
+    [1, 2]
+    ```
+
+    Example using `transformers.pipelines`:
+
+    ```python
+    >>> from transformers import {processor_class}, pipeline
+    >>> from optimum.deepsparse import {model_class}
+
+    >>> tokenizer = {processor_class}.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}")
+    >>> nm_classifier = pipeline("text-classification", model=model, tokenizer=tokenizer)
+
+    >>> text = "Hello, my dog is cute"
+    >>> pred = nm_classifier(text)
+    ```
+
+    Example using zero-shot-classification `transformers.pipelines`:
+
+    ```python
+    >>> from transformers import {processor_class}, pipeline
+    >>> from optimum.deepsparse import {model_class}
+
+    >>> tokenizer = {processor_class}.from_pretrained("optimum/distilbert-base-uncased-mnli")
+    >>> model = {model_class}.from_pretrained("optimum/distilbert-base-uncased-mnli")
+    >>> nm_z0 = pipeline("zero-shot-classification", model=model, tokenizer=tokenizer)
+
+    >>> sequence_to_classify = "Who are you voting for in 2020?"
+    >>> candidate_labels = ["Europe", "public health", "politics", "elections"]
+    >>> pred = nm_z0(sequence_to_classify, candidate_labels, multi_label=True)
+    ```
+"""
+
+
+@add_start_docstrings(
+    """
+    DeepSparse Model with a sequence classification/regression head on top (a linear layer on top of the
+    pooled output) e.g. for GLUE tasks.
+    """,
+    MODEL_START_DOCSTRING,
+)
+class DeepSparseModelForSequenceClassification(DeepSparseModel):
+    auto_model_class = AutoModelForSequenceClassification
+
+    @add_start_docstrings_to_model_forward(
+        TEXT_INPUTS_DOCSTRING.format("batch_size, sequence_length")
+        + SEQUENCE_CLASSIFICATION_EXAMPLE.format(
+            processor_class=_TOKENIZER_FOR_DOC,
+            model_class="DeepSparseModelForSequenceClassification",
+            checkpoint="optimum/distilbert-base-uncased-finetuned-sst-2-english",
+        )
+    )
+    def forward(
+        self,
+        input_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        attention_mask: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        token_type_ids: Optional[Union[torch.Tensor, np.ndarray]] = None,
+        **kwargs,
+    ):
+        self.compile()
+
+        use_torch = isinstance(input_ids, torch.Tensor)
+        if use_torch:
+            input_ids = input_ids.cpu().detach().numpy()
+            attention_mask = attention_mask.cpu().detach().numpy()
+            if token_type_ids is not None:
+                token_type_ids = token_type_ids.cpu().detach().numpy()
+
+        inputs = [input_ids, attention_mask]
+        if token_type_ids is not None:
+            inputs.append(token_type_ids)
+
+        outputs = self.deepsparse_engine(inputs)
+        logits = torch.from_numpy(outputs[0]) if use_torch else outputs[0]
+
+        # converts output to namedtuple for pipelines post-processing
+        return SequenceClassifierOutput(logits=logits)

--- a/optimum/deepsparse/modeling_base.py
+++ b/optimum/deepsparse/modeling_base.py
@@ -147,7 +147,6 @@ class DeepSparseBaseModel(OptimizedModel):
                 f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not accept those arguments."
             )
 
-
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting it
         # would end-up removing the directory containing the underlying ONNX model.
         self._model_save_dir_tempdirectory_instance = None
@@ -163,7 +162,7 @@ class DeepSparseBaseModel(OptimizedModel):
 
         self.preprocessors = preprocessors if preprocessors is not None else []
 
-        # Registers the DeepSparseModelForXXX classes into the transformers AutoModel classes to avoid warnings when creating a pipeline 
+        # Registers the DeepSparseModelForXXX classes into the transformers AutoModel classes to avoid warnings when creating a pipeline
         # https://github.com/huggingface/transformers/blob/cad61b68396a1a387287a8e2e2fef78a25b79383/src/transformers/pipelines/base.py#L863
         AutoConfig.register(self.model_type, AutoConfig)
         if hasattr(self.auto_model_class, "register"):

--- a/optimum/deepsparse/modeling_base.py
+++ b/optimum/deepsparse/modeling_base.py
@@ -1,15 +1,17 @@
 import logging
 import os
+import re
 from pathlib import Path
-from typing import Dict, Optional, Tuple, Union
+from tempfile import TemporaryDirectory
+from typing import Dict, List, Optional, Tuple, Union
 
 import onnx
 from huggingface_hub import hf_hub_download
 from huggingface_hub.utils import EntryNotFoundError
-from transformers import PretrainedConfig
+from transformers import AutoConfig, PretrainedConfig
 from transformers.file_utils import add_start_docstrings
 
-from deepsparse import Engine
+import deepsparse
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx import export
 from optimum.modeling_base import OptimizedModel
@@ -21,33 +23,172 @@ ONNX_WEIGHTS_NAME_STATIC = "model_static.onnx"
 logger = logging.getLogger(__name__)
 
 
+def parse_shapes(shape_string: str) -> List[List[int]]:
+    """
+    Reduces a string representation of a list of shapes to an actual list of shapes.
+    Examples:
+        "[1,2,3]" -> input0=[1,2,3]
+        "[1,2,3],[4,5,6],[7,8,9]" -> input0=[1,2,3] input1=[4,5,6] input2=[7,8,9]
+    """
+    if not shape_string:
+        return None
+
+    shapes_list = []
+    if shape_string:
+        matches = re.findall(r"\[(.*?)\],?", shape_string)
+        if matches:
+            for match in matches:
+                # Clean up stray extra brackets
+                value = match.replace("[", "").replace("]", "")
+                # Parse comma-separated dims into shape list
+                shape = [int(s) for s in value.split(",")]
+                shapes_list.append(shape)
+        else:
+            raise Exception(f"Can't parse input shapes parameter: {shape_string}")
+
+    return shapes_list
+
+
+def override_onnx_input_shapes(
+    onnx_filepath: str,
+    input_shapes: Union[List[int], List[List[int]]],
+    output_path: Optional[str] = None,
+) -> str:
+    """
+    Rewrite input shapes of ONNX model, saving the modified model and returning its path
+
+    :param onnx_filepath: File path to ONNX model. If the graph is to be
+        modified in-place, only the model graph will be loaded and modified.
+        Otherwise, the entire model will be loaded and modified, so that
+        external data are saved along the model graph.
+    :param input_shapes: Override for model's input shapes
+    :param output_path: If None, overwrite the original model file inplace. Otherwise write to path
+    :return: File path to modified ONNX model.
+        If output_path is True,
+        the modified model will be saved to the same path as the original
+        model. Else the modified model will be saved to output_path.
+    """
+    inplace = output_path is None
+
+    if input_shapes is None:
+        return onnx_filepath
+
+    model = onnx.load(onnx_filepath, load_external_data=not inplace)
+    all_inputs = model.graph.input
+    initializer_input_names = [node.name for node in model.graph.initializer]
+    external_inputs = [input for input in all_inputs if input.name not in initializer_input_names]
+
+    # Input shapes should be a list of lists, even if there is only one input
+    if not all(isinstance(inp, list) for inp in input_shapes):
+        input_shapes = [input_shapes]
+
+    # If there is a single input shape given and multiple inputs,
+    # duplicate for all inputs to apply the same shape
+    if len(input_shapes) == 1 and len(external_inputs) > 1:
+        input_shapes.extend([input_shapes[0] for _ in range(1, len(external_inputs))])
+
+    # Make sure that input shapes can map to the ONNX model
+    assert len(external_inputs) == len(
+        input_shapes
+    ), "Mismatch of number of model inputs ({}) and override shapes ({})".format(
+        len(external_inputs), len(input_shapes)
+    )
+
+    # Overwrite the input shapes of the model
+    for input_idx, external_input in enumerate(external_inputs):
+        assert len(external_input.type.tensor_type.shape.dim) == len(
+            input_shapes[input_idx]
+        ), "Input '{}' shape doesn't match shape override: {} vs {}".format(
+            external_input.name,
+            external_input.type.tensor_type.shape.dim,
+            input_shapes[input_idx],
+        )
+        for dim_idx, dim in enumerate(external_input.type.tensor_type.shape.dim):
+            dim.dim_value = input_shapes[input_idx][dim_idx]
+
+    if inplace:
+        logger.info(f"Overwriting in-place the input shapes of the model at {onnx_filepath}")
+        onnx.save(model, onnx_filepath)
+        return onnx_filepath
+    else:
+        logger.info(f"Saving new model with static input shapes at {output_path}")
+        onnx.save(model, output_path)
+        return output_path
+
+
 @add_start_docstrings(
     """
     Base DeepSparse class.
     """,
 )
 class DeepSparseBaseModel(OptimizedModel):
-    _AUTOMODELS_TO_TASKS = {cls_name: task for task, cls_name in TasksManager._TASKS_TO_AUTOMODELS.items()}
     auto_model_class = None
     export_feature = None
+
+    @classmethod
+    def _auto_model_to_task(cls, auto_model_class):
+        """
+        Get the task corresponding to a class (for example AutoModelForXXX in transformers).
+        """
+        return TasksManager.infer_task_from_model(auto_model_class)
+
+    def shared_attributes_init(
+        self,
+        model: deepsparse.Engine,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        preprocessors: Optional[List] = None,
+        **kwargs,
+    ):
+        """
+        Initializes attributes that may be shared among DeepSparse engines.
+        """
+        if kwargs:
+            raise ValueError(
+                f"{self.__class__.__name__} received {', '.join(kwargs.keys())}, but do not accept those arguments."
+            )
+
+
+        # This attribute is needed to keep one reference on the temporary directory, since garbage collecting it
+        # would end-up removing the directory containing the underlying ONNX model.
+        self._model_save_dir_tempdirectory_instance = None
+        if model_save_dir is None:
+            self.model_save_dir = Path(model._model_path).parent
+        elif isinstance(model_save_dir, TemporaryDirectory):
+            self._model_save_dir_tempdirectory_instance = model_save_dir
+            self.model_save_dir = Path(model_save_dir.name)
+        elif isinstance(model_save_dir, str):
+            self.model_save_dir = Path(model_save_dir)
+        else:
+            self.model_save_dir = model_save_dir
+
+        self.preprocessors = preprocessors if preprocessors is not None else []
+
+        # Registers the DeepSparseModelForXXX classes into the transformers AutoModel classes to avoid warnings when creating a pipeline 
+        # https://github.com/huggingface/transformers/blob/cad61b68396a1a387287a8e2e2fef78a25b79383/src/transformers/pipelines/base.py#L863
+        AutoConfig.register(self.model_type, AutoConfig)
+        if hasattr(self.auto_model_class, "register"):
+            self.auto_model_class.register(AutoConfig, self.__class__)
 
     def __init__(
         self,
         model: None,
         config: PretrainedConfig = None,
-        deepsparse_config: Optional[Dict[str, str]] = None,
-        model_save_dir: Optional[Union[str, Path]] = None,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        preprocessors: Optional[List] = None,
+        input_shapes: Optional[Union[str, List]] = None,
         input_shape_dict: Optional[Dict[str, Tuple[int]]] = None,
         output_shape_dict: Optional[Dict[str, Tuple[int]]] = None,
         **kwargs,
     ):
+        super().__init__(model, config)
+
         self.config = config
         self.model_save_dir = model_save_dir
-        self.deepsparse_config = deepsparse_config
 
         self.model = model
         self.deepsparse_engine = None
 
+        self.input_shapes = parse_shapes(input_shapes)
         self.input_shape_dict = input_shape_dict
         self.output_shape_dict = output_shape_dict
 
@@ -223,17 +364,19 @@ class DeepSparseBaseModel(OptimizedModel):
         if self.deepsparse_engine is None:
             self.is_dynamic = self._check_is_dynamic()
             if self.is_dynamic:
-                self._reshape(self.model, self.input_shape_dict, self.output_shape_dict)
+                if self.input_shapes is None and (self.input_shape_dict is None or self.output_shape_dict is None):
+                    logger.warn("Model is dynamic and has no shapes defined, skipping reshape..")
+                    self.deepsparse_engine = deepsparse.Engine(model=self.model, batch_size=batch_size)
+                    return
+                self._reshape(self.model)
 
-            logger.info("Compiling the model and creating the engine...")
-            self.deepsparse_engine = Engine(model=self.model, batch_size=batch_size)
+            logger.info("Compiling...")
+            self.deepsparse_engine = deepsparse.Engine(model=self.model, batch_size=batch_size)
             logger.info(self.deepsparse_engine)
 
     def _reshape(
         self,
         model_path,
-        input_shape_dict,
-        output_shape_dict,
     ):
         """
         Propagates the given input shapes on the model's layers, fixing the inputs shapes of the model.
@@ -241,10 +384,6 @@ class DeepSparseBaseModel(OptimizedModel):
         Arguments:
             model_path (`int`):
                 Path to the model.
-            input_shape_dict (`int`):
-                Input shapes for the model.
-            output_shape_dict (`int`):
-                Output shapes for the model.
         """
         # Reset the engine so we know to recompile
         self.deepsparse_engine = None
@@ -252,27 +391,46 @@ class DeepSparseBaseModel(OptimizedModel):
         if not isinstance(model_path, str) or not model_path.endswith(".onnx"):
             raise ValueError("The model_path isn't a path to an ONNX '{model_path}'")
 
-        if input_shape_dict is None or output_shape_dict is None:
+        if self.input_shapes is None and (self.input_shape_dict is None or self.output_shape_dict is None):
             raise ValueError(
-                "The model provided has dynamic axes in input / output, please provide input and output shapes for compilation!"
+                "The model provided has dynamic axes in input, please provide `input_shapes` for compilation!"
             )
-        from onnx import shape_inference
-        from onnx.tools import update_model_dims
-
-        model = onnx.load(model_path)
-        updated_model = update_model_dims.update_inputs_outputs_dims(model, input_shape_dict, output_shape_dict)
-        inferred_model = shape_inference.infer_shapes(updated_model)
 
         static_model_path = str(Path(model_path).parent / ONNX_WEIGHTS_NAME_STATIC)
-        onnx.save(inferred_model, static_model_path)
-        self.model = static_model_path
+
+        if self.input_shapes:
+            self.model = override_onnx_input_shapes(
+                model_path, input_shapes=self.input_shapes, output_path=static_model_path
+            )
+        else:
+            from onnx import shape_inference
+            from onnx.tools import update_model_dims
+
+            model = onnx.load(model_path)
+            updated_model = update_model_dims.update_inputs_outputs_dims(
+                model, self.input_shape_dict, self.output_shape_dict
+            )
+            inferred_model = shape_inference.infer_shapes(updated_model)
+
+            onnx.save(inferred_model, static_model_path)
+            self.model = static_model_path
+
+    def reshape(
+        self,
+        input_shapes: Optional[Union[str, List]] = None,
+        input_shape_dict: Optional[Dict[str, Tuple[int]]] = None,
+        output_shape_dict: Optional[Dict[str, Tuple[int]]] = None,
+    ):
+        if input_shapes:
+            self.input_shapes = parse_shapes(input_shapes)
+
+        if input_shape_dict:
+            self.input_shape_dict = input_shape_dict
+
+        if output_shape_dict:
+            self.output_shape_dict = output_shape_dict
+
+        self._reshape(self.model)
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError
-
-    @classmethod
-    def _auto_model_to_task(cls, auto_model_class):
-        """
-        Get the task corresponding to a class (for example AutoModelForXXX in transformers).
-        """
-        return cls._AUTOMODELS_TO_TASKS[auto_model_class.__name__]

--- a/tests/deepsparse/test_modeling.py
+++ b/tests/deepsparse/test_modeling.py
@@ -15,6 +15,7 @@
 import gc
 import unittest
 
+import pytest
 import numpy as np
 import requests
 import torch
@@ -22,13 +23,17 @@ from parameterized import parameterized
 from PIL import Image
 from transformers import (
     AutoFeatureExtractor,
+    AutoTokenizer,
     AutoModelForImageClassification,
+    AutoModelForSequenceClassification,
     PretrainedConfig,
     pipeline,
     set_seed,
 )
+from transformers.onnx.utils import get_preprocessor
 
-from optimum.deepsparse import DeepSparseModelForImageClassification
+import deepsparse
+from optimum.deepsparse import DeepSparseModelForImageClassification, DeepSparseModelForSequenceClassification
 from optimum.utils import (
     logging,
 )
@@ -38,25 +43,48 @@ SEED = 42
 
 logger = logging.get_logger()
 
+SEQLEN = 128
+DEFAULT_TOKEN_SHAPES = f"[1,{SEQLEN}]"
+DEFAULT_PADDING_KWARGS = {"padding":"max_length",
+    "max_length": SEQLEN,
+    "truncation":True,}
+
+class ModelInfo:
+    def __init__(self, model_id: str, input_shapes: str = None, padding_kwargs: dict = None):
+        self.model_id = model_id
+        self.input_shapes = input_shapes
+        self.padding_kwargs = padding_kwargs
+
 MODEL_DICT = {
-    "mobilenet_v1": [
-        "google/mobilenet_v1_0.75_192",
-        "[1, 3, 192, 192]",
-        {"pixel_values": [1, 3, 192, 192]},
-        {"logits": [1, 1001]},
-    ],
-    "mobilenet_v2": [
-        "hf-internal-testing/tiny-random-MobileNetV2Model",
-        "[1, 3, 32, 32]",
-        {"pixel_values": [1, 3, 32, 32]},
-        {"logits": [1, 2]},
-    ],
-    "resnet": [
-        "hf-internal-testing/tiny-random-resnet",
-        "[1, 3, 224, 224]",
-        {"pixel_values": [1, 3, 224, 224]},
-        {"logits": [1, 1000]},
-    ],
+    "albert": ModelInfo("hf-internal-testing/tiny-random-AlbertModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "beit": ModelInfo("hf-internal-testing/tiny-random-BeitForImageClassification"),
+    "bert": ModelInfo("hf-internal-testing/tiny-random-BertModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "bart": ModelInfo("hf-internal-testing/tiny-random-bart", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "camembert": ModelInfo("hf-internal-testing/tiny-random-camembert", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "convbert": ModelInfo("hf-internal-testing/tiny-random-ConvBertModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "deberta": ModelInfo("hf-internal-testing/tiny-random-DebertaModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "deberta_v2": ModelInfo("hf-internal-testing/tiny-random-DebertaV2Model", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "deit": ModelInfo("hf-internal-testing/tiny-random-DeiTModel"),
+    "convnext": ModelInfo("hf-internal-testing/tiny-random-convnext"),
+    "detr": ModelInfo("hf-internal-testing/tiny-random-detr"),
+    "distilbert": ModelInfo("hf-internal-testing/tiny-random-DistilBertModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "ibert": ModelInfo("hf-internal-testing/tiny-random-IBertModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "mbart": ModelInfo("hf-internal-testing/tiny-random-mbart", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "mobilebert": ModelInfo("hf-internal-testing/tiny-random-MobileBertModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "mobilenet_v1": ModelInfo("google/mobilenet_v1_0.75_192", "[1,3,192,192]"),
+    "mobilenet_v2": ModelInfo("hf-internal-testing/tiny-random-MobileNetV2Model", "[1,3,32,32]"),
+    "mobilevit": ModelInfo("hf-internal-testing/tiny-random-mobilevit"),
+    "nystromformer": ModelInfo("hf-internal-testing/tiny-random-NystromformerModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "resnet": ModelInfo("hf-internal-testing/tiny-random-resnet", "[1,3,224,224]"),
+    "roberta": ModelInfo("hf-internal-testing/tiny-random-RobertaModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "roformer": ModelInfo("hf-internal-testing/tiny-random-RoFormerModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "squeezebert": ModelInfo("hf-internal-testing/tiny-random-SqueezeBertModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "swin": ModelInfo("hf-internal-testing/tiny-random-SwinModel"),
+    "t5": ModelInfo("hf-internal-testing/tiny-random-t5"),
+    "vit": ModelInfo("hf-internal-testing/tiny-random-vit"),
+    "yolos": ModelInfo("hf-internal-testing/tiny-random-YolosModel"),
+    "xlm": ModelInfo("hf-internal-testing/tiny-random-XLMModel", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
+    "xlm_roberta": ModelInfo("hf-internal-testing/tiny-xlm-roberta", DEFAULT_TOKEN_SHAPES, DEFAULT_PADDING_KWARGS),
 }
 
 
@@ -66,64 +94,130 @@ TENSOR_ALIAS_TO_TYPE = {
 }
 
 
-class DeepSparseModelForImageClassificationIntegrationTest(unittest.TestCase):
+class DeepSparseModelForSequenceClassificationIntegrationTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES = [
-        "mobilenet_v1",
-        "mobilenet_v2",
-        "resnet",
+        "albert",
+        # "bart",
+        "bert",
+        "camembert",
+        "convbert",
+        "deberta",
+        "deberta_v2",
+        "distilbert",
+        # "ibert",
+        # "mbart",
+        "mobilebert",
+        "nystromformer",
+        "roberta",
+        "roformer",
+        # "squeezebert",
+        # "xlm",
+        # "xlm_roberta",
     ]
+
+    ARCH_MODEL_MAP = {
+    }
+
+    FULL_GRID = {"model_arch": SUPPORTED_ARCHITECTURES}
+    MODEL_CLASS = DeepSparseModelForSequenceClassification
+    TASK = "text-classification"
+
+    def test_load_vanilla_transformers_which_is_not_supported(self):
+        with self.assertRaises(Exception) as context:
+            _ = self.MODEL_CLASS.from_pretrained(MODEL_DICT["t5"].model_id, export=True)
+
+        self.assertIn("Unrecognized configuration class", str(context.exception))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):
-        model_id, input_shapes, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
+        # model_args = {"test_name": model_arch, "model_arch": model_arch}
+        # self._setup(model_args)
+
+        model_info = self.ARCH_MODEL_MAP[model_arch] if model_arch in self.ARCH_MODEL_MAP else MODEL_DICT[model_arch]
+        model_id = model_info.model_id
+        input_shapes = model_info.input_shapes
+        padding_kwargs = model_info.padding_kwargs
+        # onnx_model = self.MODEL_CLASS.from_pretrained(self.onnx_model_dirs[model_arch])
+        onnx_model = self.MODEL_CLASS.from_pretrained(model_id, export=True, input_shapes=input_shapes)
+
+        self.assertIsInstance(onnx_model.config, PretrainedConfig)
+
         set_seed(SEED)
-        nm_model1 = DeepSparseModelForImageClassification.from_pretrained(
-            model_id, export=True, input_shapes=input_shapes
-        )
-        nm_model2 = DeepSparseModelForImageClassification.from_pretrained(
-            model_id, export=True, input_shape_dict=input_shape_dict, output_shape_dict=output_shape_dict
-        )
-        self.assertIsInstance(nm_model1.config, PretrainedConfig)
-        self.assertIsInstance(nm_model2.config, PretrainedConfig)
-        transformers_model = AutoModelForImageClassification.from_pretrained(model_id)
-        preprocessor = AutoFeatureExtractor.from_pretrained(model_id)
-        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-        image = Image.open(requests.get(url, stream=True).raw)
-        inputs = preprocessor(images=image, return_tensors="pt")
+        transformers_model = AutoModelForSequenceClassification.from_pretrained(model_id)
+        tokenizer = get_preprocessor(model_id)
+
+        text = "This is a sample output"
+        tokens = tokenizer(text, return_tensors="pt", **padding_kwargs)
         with torch.no_grad():
-            transformers_outputs = transformers_model(**inputs)
+            transformers_outputs = transformers_model(**tokens)
+
         for input_type in ["pt", "np"]:
-            inputs = preprocessor(images=image, return_tensors=input_type)
-            nm_outputs1 = nm_model1(**inputs)
-            nm_outputs2 = nm_model2(**inputs)
-            self.assertTrue(nm_model1.deepsparse_engine.fraction_of_supported_ops >= 0.99)
-            self.assertTrue(nm_model2.deepsparse_engine.fraction_of_supported_ops >= 0.99)
-            self.assertIn("logits", nm_outputs1)
-            self.assertIn("logits", nm_outputs2)
-            self.assertIsInstance(nm_outputs1.logits, TENSOR_ALIAS_TO_TYPE[input_type])
-            self.assertIsInstance(nm_outputs2.logits, TENSOR_ALIAS_TO_TYPE[input_type])
-            # Compare tensor outputs
-            self.assertTrue(torch.allclose(torch.Tensor(nm_outputs1.logits), transformers_outputs.logits, atol=1e-4))
-            self.assertTrue(torch.allclose(torch.Tensor(nm_outputs2.logits), transformers_outputs.logits, atol=1e-4))
+            tokens = tokenizer(text, return_tensors=input_type, **padding_kwargs)
+            onnx_outputs = onnx_model(**tokens)
+
+            self.assertIn("logits", onnx_outputs)
+            self.assertIsInstance(onnx_outputs.logits, TENSOR_ALIAS_TO_TYPE[input_type])
+            self.assertIsInstance(onnx_model.deepsparse_engine, deepsparse.Engine)
+            self.assertTrue(onnx_model.deepsparse_engine.fraction_of_supported_ops >= 0.9)
+
+            # compare tensor outputs
+            # print("=====")
+            # print(torch.Tensor(onnx_outputs.logits))
+            # print("-----")
+            # print(transformers_outputs.logits)
+            self.assertTrue(torch.allclose(torch.Tensor(onnx_outputs.logits), transformers_outputs.logits, atol=1e-1))
 
         gc.collect()
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    def test_pipeline(self, model_arch):
-        model_id, input_shapes, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
-        model1 = DeepSparseModelForImageClassification.from_pretrained(
-            model_id, export=True, input_shapes=input_shapes
-        )
-        model2 = DeepSparseModelForImageClassification.from_pretrained(
-            model_id, export=True, input_shape_dict=input_shape_dict, output_shape_dict=output_shape_dict
-        )
-        preprocessor = AutoFeatureExtractor.from_pretrained(model_id)
-        pipe1 = pipeline("image-classification", model=model1, feature_extractor=preprocessor)
-        pipe2 = pipeline("image-classification", model=model2, feature_extractor=preprocessor)
-        outputs1 = pipe1("http://images.cocodataset.org/val2017/000000039769.jpg")
-        outputs2 = pipe2("http://images.cocodataset.org/val2017/000000039769.jpg")
-        self.assertGreaterEqual(outputs1[0]["score"], 0.0)
-        self.assertGreaterEqual(outputs2[0]["score"], 0.0)
-        self.assertTrue(isinstance(outputs1[0]["label"], str))
-        self.assertTrue(isinstance(outputs2[0]["label"], str))
+    def test_pipeline_nm_model(self, model_arch):
+        # model_args = {"test_name": model_arch, "model_arch": model_arch}
+        # self._setup(model_args)
+
+        model_info = self.ARCH_MODEL_MAP[model_arch] if model_arch in self.ARCH_MODEL_MAP else MODEL_DICT[model_arch]
+        model_id = model_info.model_id
+        input_shapes = model_info.input_shapes
+        padding_kwargs = model_info.padding_kwargs
+
+        onnx_model = self.MODEL_CLASS.from_pretrained(model_id, export=True, input_shapes=input_shapes)
+        tokenizer = get_preprocessor(model_id)
+        pipe = pipeline("text-classification", model=onnx_model, tokenizer=tokenizer, **padding_kwargs)
+        text = "My Name is Philipp and i live in Germany."
+        outputs = pipe(text)
+
+        self.assertGreaterEqual(outputs[0]["score"], 0.0)
+        self.assertIsInstance(outputs[0]["label"], str)
+        self.assertTrue(onnx_model.deepsparse_engine.fraction_of_supported_ops >= 0.9)
+
         gc.collect()
+
+    @pytest.mark.run_in_series
+    def test_pipeline_model_is_none(self):
+        pipe = pipeline("text-classification")
+        text = "My Name is Philipp and i live in Germany."
+        outputs = pipe(text)
+
+        # compare model output class
+        self.assertGreaterEqual(outputs[0]["score"], 0.0)
+        self.assertIsInstance(outputs[0]["label"], str)
+
+    def test_pipeline_zero_shot_classification(self):
+        onnx_model = self.MODEL_CLASS.from_pretrained(
+            "typeform/distilbert-base-uncased-mnli", export=True#, input_shapes=DEFAULT_TOKEN_SHAPES
+        )
+        tokenizer = get_preprocessor("typeform/distilbert-base-uncased-mnli")
+        # TODO: padding doesn't work
+        # pipe = pipeline("zero-shot-classification", model=onnx_model, tokenizer=tokenizer, **DEFAULT_PADDING_KWARGS)
+        pipe = pipeline("zero-shot-classification", model=onnx_model, tokenizer=tokenizer)
+        sequence_to_classify = "Who are you voting for in 2020?"
+        candidate_labels = ["Europe", "public health", "politics", "elections"]
+        hypothesis_template = "This text is about {}."
+        outputs = pipe(
+            sequence_to_classify, candidate_labels, multi_class=True, hypothesis_template=hypothesis_template
+        )
+
+        # compare model output class
+        self.assertTrue(all(score > 0.0 for score in outputs["scores"]))
+        self.assertTrue(all(isinstance(label, str) for label in outputs["labels"]))
+        # TODO: fix padding
+        # self.assertTrue(onnx_model.deepsparse_engine.fraction_of_supported_ops >= 0.9)

--- a/tests/deepsparse/test_modeling.py
+++ b/tests/deepsparse/test_modeling.py
@@ -20,9 +20,15 @@ import requests
 import torch
 from parameterized import parameterized
 from PIL import Image
-from transformers import AutoFeatureExtractor, AutoModelForImageClassification, AutoModelForSequenceClassification, PretrainedConfig, pipeline, set_seed
+from transformers import (
+    AutoFeatureExtractor,
+    AutoModelForImageClassification,
+    PretrainedConfig,
+    pipeline,
+    set_seed,
+)
 
-from optimum.deepsparse import DeepSparseModelForImageClassification, DeepSparseModelForSequenceClassification
+from optimum.deepsparse import DeepSparseModelForImageClassification
 from optimum.utils import (
     logging,
 )
@@ -33,13 +39,24 @@ SEED = 42
 logger = logging.get_logger()
 
 MODEL_DICT = {
-    "mobilenet_v1": ["google/mobilenet_v1_0.75_192", "[1, 3, 192, 192]", {"pixel_values": [1, 3, 192, 192]}, {"logits": [1, 1001]}],
+    "mobilenet_v1": [
+        "google/mobilenet_v1_0.75_192",
+        "[1, 3, 192, 192]",
+        {"pixel_values": [1, 3, 192, 192]},
+        {"logits": [1, 1001]},
+    ],
     "mobilenet_v2": [
-        "hf-internal-testing/tiny-random-MobileNetV2Model", "[1, 3, 32, 32]",
+        "hf-internal-testing/tiny-random-MobileNetV2Model",
+        "[1, 3, 32, 32]",
         {"pixel_values": [1, 3, 32, 32]},
         {"logits": [1, 2]},
     ],
-    "resnet": ["hf-internal-testing/tiny-random-resnet",  "[1, 3, 224, 224]", {"pixel_values": [1, 3, 224, 224]}, {"logits": [1, 1000]}],
+    "resnet": [
+        "hf-internal-testing/tiny-random-resnet",
+        "[1, 3, 224, 224]",
+        {"pixel_values": [1, 3, 224, 224]},
+        {"logits": [1, 1000]},
+    ],
 }
 
 

--- a/tests/deepsparse/test_modeling.py
+++ b/tests/deepsparse/test_modeling.py
@@ -20,9 +20,9 @@ import requests
 import torch
 from parameterized import parameterized
 from PIL import Image
-from transformers import AutoFeatureExtractor, AutoModelForImageClassification, PretrainedConfig, pipeline, set_seed
+from transformers import AutoFeatureExtractor, AutoModelForImageClassification, AutoModelForSequenceClassification, PretrainedConfig, pipeline, set_seed
 
-from optimum.deepsparse import DeepSparseModelForImageClassification
+from optimum.deepsparse import DeepSparseModelForImageClassification, DeepSparseModelForSequenceClassification
 from optimum.utils import (
     logging,
 )
@@ -33,13 +33,13 @@ SEED = 42
 logger = logging.get_logger()
 
 MODEL_DICT = {
-    "mobilenet_v1": ["google/mobilenet_v1_0.75_192", {"pixel_values": [1, 3, 192, 192]}, {"logits": [1, 1001]}],
+    "mobilenet_v1": ["google/mobilenet_v1_0.75_192", "[1, 3, 192, 192]", {"pixel_values": [1, 3, 192, 192]}, {"logits": [1, 1001]}],
     "mobilenet_v2": [
-        "hf-internal-testing/tiny-random-MobileNetV2Model",
+        "hf-internal-testing/tiny-random-MobileNetV2Model", "[1, 3, 32, 32]",
         {"pixel_values": [1, 3, 32, 32]},
         {"logits": [1, 2]},
     ],
-    "resnet": ["hf-internal-testing/tiny-random-resnet", {"pixel_values": [1, 3, 224, 224]}, {"logits": [1, 1000]}],
+    "resnet": ["hf-internal-testing/tiny-random-resnet",  "[1, 3, 224, 224]", {"pixel_values": [1, 3, 224, 224]}, {"logits": [1, 1000]}],
 }
 
 
@@ -58,12 +58,16 @@ class DeepSparseModelForImageClassificationIntegrationTest(unittest.TestCase):
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):
-        model_id, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
+        model_id, input_shapes, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
         set_seed(SEED)
-        nm_model = DeepSparseModelForImageClassification.from_pretrained(
+        nm_model1 = DeepSparseModelForImageClassification.from_pretrained(
+            model_id, export=True, input_shapes=input_shapes
+        )
+        nm_model2 = DeepSparseModelForImageClassification.from_pretrained(
             model_id, export=True, input_shape_dict=input_shape_dict, output_shape_dict=output_shape_dict
         )
-        self.assertIsInstance(nm_model.config, PretrainedConfig)
+        self.assertIsInstance(nm_model1.config, PretrainedConfig)
+        self.assertIsInstance(nm_model2.config, PretrainedConfig)
         transformers_model = AutoModelForImageClassification.from_pretrained(model_id)
         preprocessor = AutoFeatureExtractor.from_pretrained(model_id)
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -73,24 +77,36 @@ class DeepSparseModelForImageClassificationIntegrationTest(unittest.TestCase):
             transformers_outputs = transformers_model(**inputs)
         for input_type in ["pt", "np"]:
             inputs = preprocessor(images=image, return_tensors=input_type)
-            nm_outputs = nm_model(**inputs)
-            self.assertTrue(nm_model.deepsparse_engine.fraction_of_supported_ops >= 0.99)
-            self.assertIn("logits", nm_outputs)
-            self.assertIsInstance(nm_outputs.logits, TENSOR_ALIAS_TO_TYPE[input_type])
+            nm_outputs1 = nm_model1(**inputs)
+            nm_outputs2 = nm_model2(**inputs)
+            self.assertTrue(nm_model1.deepsparse_engine.fraction_of_supported_ops >= 0.99)
+            self.assertTrue(nm_model2.deepsparse_engine.fraction_of_supported_ops >= 0.99)
+            self.assertIn("logits", nm_outputs1)
+            self.assertIn("logits", nm_outputs2)
+            self.assertIsInstance(nm_outputs1.logits, TENSOR_ALIAS_TO_TYPE[input_type])
+            self.assertIsInstance(nm_outputs2.logits, TENSOR_ALIAS_TO_TYPE[input_type])
             # Compare tensor outputs
-            self.assertTrue(torch.allclose(torch.Tensor(nm_outputs.logits), transformers_outputs.logits, atol=1e-4))
+            self.assertTrue(torch.allclose(torch.Tensor(nm_outputs1.logits), transformers_outputs.logits, atol=1e-4))
+            self.assertTrue(torch.allclose(torch.Tensor(nm_outputs2.logits), transformers_outputs.logits, atol=1e-4))
 
         gc.collect()
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_pipeline(self, model_arch):
-        model_id, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
-        model = DeepSparseModelForImageClassification.from_pretrained(
+        model_id, input_shapes, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
+        model1 = DeepSparseModelForImageClassification.from_pretrained(
+            model_id, export=True, input_shapes=input_shapes
+        )
+        model2 = DeepSparseModelForImageClassification.from_pretrained(
             model_id, export=True, input_shape_dict=input_shape_dict, output_shape_dict=output_shape_dict
         )
         preprocessor = AutoFeatureExtractor.from_pretrained(model_id)
-        pipe = pipeline("image-classification", model=model, feature_extractor=preprocessor)
-        outputs = pipe("http://images.cocodataset.org/val2017/000000039769.jpg")
-        self.assertGreaterEqual(outputs[0]["score"], 0.0)
-        self.assertTrue(isinstance(outputs[0]["label"], str))
+        pipe1 = pipeline("image-classification", model=model1, feature_extractor=preprocessor)
+        pipe2 = pipeline("image-classification", model=model2, feature_extractor=preprocessor)
+        outputs1 = pipe1("http://images.cocodataset.org/val2017/000000039769.jpg")
+        outputs2 = pipe2("http://images.cocodataset.org/val2017/000000039769.jpg")
+        self.assertGreaterEqual(outputs1[0]["score"], 0.0)
+        self.assertGreaterEqual(outputs2[0]["score"], 0.0)
+        self.assertTrue(isinstance(outputs1[0]["label"], str))
+        self.assertTrue(isinstance(outputs2[0]["label"], str))
         gc.collect()

--- a/tests/deepsparse/test_smoke.py
+++ b/tests/deepsparse/test_smoke.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import gc
+import unittest
+
+import numpy as np
+import requests
+import torch
+from parameterized import parameterized
+from PIL import Image
+from transformers import (
+    AutoFeatureExtractor,
+    AutoModelForImageClassification,
+    PretrainedConfig,
+    pipeline,
+    set_seed,
+)
+
+from optimum.deepsparse import DeepSparseModelForImageClassification
+from optimum.utils import (
+    logging,
+)
+
+
+SEED = 42
+
+logger = logging.get_logger()
+
+MODEL_DICT = {
+    "mobilenet_v1": [
+        "google/mobilenet_v1_0.75_192",
+        "[1, 3, 192, 192]",
+        {"pixel_values": [1, 3, 192, 192]},
+        {"logits": [1, 1001]},
+    ],
+    "mobilenet_v2": [
+        "hf-internal-testing/tiny-random-MobileNetV2Model",
+        "[1, 3, 32, 32]",
+        {"pixel_values": [1, 3, 32, 32]},
+        {"logits": [1, 2]},
+    ],
+    "resnet": [
+        "hf-internal-testing/tiny-random-resnet",
+        "[1, 3, 224, 224]",
+        {"pixel_values": [1, 3, 224, 224]},
+        {"logits": [1, 1000]},
+    ],
+}
+
+
+TENSOR_ALIAS_TO_TYPE = {
+    "pt": torch.Tensor,
+    "np": np.ndarray,
+}
+
+
+class DeepSparseModelForImageClassificationIntegrationTest(unittest.TestCase):
+    SUPPORTED_ARCHITECTURES = [
+        "mobilenet_v1",
+        "mobilenet_v2",
+        "resnet",
+    ]
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_compare_to_transformers(self, model_arch):
+        model_id, input_shapes, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
+        set_seed(SEED)
+        nm_model1 = DeepSparseModelForImageClassification.from_pretrained(
+            model_id, export=True, input_shapes=input_shapes
+        )
+        nm_model2 = DeepSparseModelForImageClassification.from_pretrained(
+            model_id, export=True, input_shape_dict=input_shape_dict, output_shape_dict=output_shape_dict
+        )
+        self.assertIsInstance(nm_model1.config, PretrainedConfig)
+        self.assertIsInstance(nm_model2.config, PretrainedConfig)
+        transformers_model = AutoModelForImageClassification.from_pretrained(model_id)
+        preprocessor = AutoFeatureExtractor.from_pretrained(model_id)
+        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+        inputs = preprocessor(images=image, return_tensors="pt")
+        with torch.no_grad():
+            transformers_outputs = transformers_model(**inputs)
+        for input_type in ["pt", "np"]:
+            inputs = preprocessor(images=image, return_tensors=input_type)
+            nm_outputs1 = nm_model1(**inputs)
+            nm_outputs2 = nm_model2(**inputs)
+            print(nm_model1.deepsparse_engine)
+            print(nm_model2.deepsparse_engine)
+            self.assertTrue(nm_model1.deepsparse_engine.fraction_of_supported_ops >= 0.9)
+            self.assertTrue(nm_model2.deepsparse_engine.fraction_of_supported_ops >= 0.9)
+            self.assertIn("logits", nm_outputs1)
+            self.assertIn("logits", nm_outputs2)
+            self.assertIsInstance(nm_outputs1.logits, TENSOR_ALIAS_TO_TYPE[input_type])
+            self.assertIsInstance(nm_outputs2.logits, TENSOR_ALIAS_TO_TYPE[input_type])
+            # Compare tensor outputs
+            self.assertTrue(torch.allclose(torch.Tensor(nm_outputs1.logits), transformers_outputs.logits, atol=1e-4))
+            self.assertTrue(torch.allclose(torch.Tensor(nm_outputs2.logits), transformers_outputs.logits, atol=1e-4))
+
+        gc.collect()
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_pipeline(self, model_arch):
+        model_id, input_shapes, input_shape_dict, output_shape_dict = MODEL_DICT[model_arch]
+        model1 = DeepSparseModelForImageClassification.from_pretrained(
+            model_id, export=True, input_shapes=input_shapes
+        )
+        model2 = DeepSparseModelForImageClassification.from_pretrained(
+            model_id, export=True, input_shape_dict=input_shape_dict, output_shape_dict=output_shape_dict
+        )
+        preprocessor = AutoFeatureExtractor.from_pretrained(model_id)
+        pipe1 = pipeline("image-classification", model=model1, feature_extractor=preprocessor)
+        pipe2 = pipeline("image-classification", model=model2, feature_extractor=preprocessor)
+        outputs1 = pipe1("http://images.cocodataset.org/val2017/000000039769.jpg")
+        outputs2 = pipe2("http://images.cocodataset.org/val2017/000000039769.jpg")
+        self.assertGreaterEqual(outputs1[0]["score"], 0.0)
+        self.assertGreaterEqual(outputs2[0]["score"], 0.0)
+        self.assertTrue(isinstance(outputs1[0]["label"], str))
+        self.assertTrue(isinstance(outputs2[0]["label"], str))
+        gc.collect()


### PR DESCRIPTION
Adds in `DeepSparseModelForSequenceClassification` for `text-classification` pipelines and adds a simpler static shape parameter called `input_shape` that acts like deepsparse Engine expects

```python
from transformers import AutoTokenizer, pipeline
from optimum.deepsparse import DeepSparseModelForSequenceClassification

model_id = "distilbert-base-uncased-finetuned-sst-2-english"
seq_length = 128
input_shape = f"[1,{seq_length}]"
model = DeepSparseModelForSequenceClassification.from_pretrained(
    model_id,
    export=True,
    input_shape=input_shape,
)
tokenizer = AutoTokenizer.from_pretrained(model_id)
pipe = pipeline(
    "text-classification",
    model=model,
    tokenizer=tokenizer,
    padding="max_length",
    max_length=seq_length,
    truncation=True,
)

outputs = pipe("Hi I like you")
print(model.deepsparse_engine.fraction_of_supported_ops)
print(outputs)
# 0.9939
# [{'label': 'POSITIVE', 'score': 0.9997448325157166}]
```