### PR TITLE
Add custom_onnx_configs to from_pretrained

### DIFF
--- a/optimum/deepsparse/modeling_base.py
+++ b/optimum/deepsparse/modeling_base.py
@@ -355,6 +355,7 @@ class DeepSparseBaseModel(OptimizedModel):
         local_files_only: bool = False,
         trust_remote_code: bool = False,
         task: Optional[str] = None,
+        custom_onnx_configs: Optional[Dict[str, "OnnxConfig"]] = None,
         **kwargs,
     ):
         """
@@ -372,6 +373,8 @@ class DeepSparseBaseModel(OptimizedModel):
                 Is needed to load models from a private repository
             revision (`str`):
                 Revision is the specific model version to use. It can be a branch name, a tag name, or a commit id
+            custom_onnx_configs (`Optional[Dict[str, OnnxConfig]]`, defaults to `None`):
+                Experimental usage: override the default ONNX config used for the given model. This argument may be useful for advanced users that desire a finer-grained control on the export. An example is available [here](https://huggingface.co/docs/optimum/main/en/exporters/onnx/usage_guides/export_a_model).
             kwargs (`Dict`, *optional*):
                 kwargs will be passed to the model during initialization
         """
@@ -394,6 +397,7 @@ class DeepSparseBaseModel(OptimizedModel):
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
+            custom_onnx_configs=custom_onnx_configs,
         )
 
         config.save_pretrained(save_dir_path)


### PR DESCRIPTION
```python
from transformers import AutoConfig, EfficientFormerImageProcessor, pipeline
from optimum.deepsparse import DeepSparseModelForImageClassification
from optimum.exporters.onnx.model_configs import ViTOnnxConfig
​
​
model_id = "snap-research/efficientformer-l1-300"
task = "image-classification"
image_model = DeepSparseModelForImageClassification.from_pretrained(
    model_id,
    task=task,
    custom_onnx_configs={
        "model": ViTOnnxConfig(
            config=AutoConfig.from_pretrained(model_id),
            task=task,
        ),
    },
    export=True,
    input_shapes="[1,3,224,224]",
)
processor = EfficientFormerImageProcessor.from_pretrained(model_id)
cls_pipe = pipeline(task, model=image_model, feature_extractor=processor)
​
outputs = cls_pipe("http://images.cocodataset.org/val2017/000000039769.jpg")
print(outputs)
# [{'score': 0.7561629414558411, 'label': 'LABEL_281'}, 
#  {'score': 0.09753969311714172, 'label': 'LABEL_285'}, 
#  {'score': 0.0808626264333725, 'label': 'LABEL_282'}, 
#  {'score': 0.019378826022148132, 'label': 'LABEL_761'}, 
#  {'score': 0.002226506359875202, 'label': 'LABEL_811'}]
```